### PR TITLE
Use json private key for oauth2client v2.0.0+

### DIFF
--- a/demos/server-auth/config.py
+++ b/demos/server-auth/config.py
@@ -1,17 +1,15 @@
 #!/usr/bin/env python
 """An example config.py file."""
 
-
 import ee
+from oauth2client.service_account import ServiceAccountCredentials
 
-# The service account email address authorized by your Google contact.
-# Set up a service account as described in the README.
-EE_ACCOUNT = 'your-service-account-id@developer.gserviceaccount.com'
+# Set up a service account as described in the README, and generate a 
+# a private key in JSON format via the Google API Console.
+# https://console.cloud.google.com/iam-admin/serviceaccounts/
 
-# The private key associated with your service account in Privacy Enhanced
-# Email format (.pem suffix).  To convert a private key from the RSA format
-# (.p12 suffix) to .pem, run the openssl command like this:
-# openssl pkcs12 -in downloaded-privatekey.p12 -nodes -nocerts > privatekey.pem
-EE_PRIVATE_KEY_FILE = 'privatekey.pem'
+EE_SCOPE = 'https://www.googleapis.com/auth/earthengine'
+EE_PRIVATE_KEY_FILE = 'privatekey.json'
 
-EE_CREDENTIALS = ee.ServiceAccountCredentials(EE_ACCOUNT, EE_PRIVATE_KEY_FILE)
+EE_CREDENTIALS = ServiceAccountCredentials(
+  EE_PRIVATE_KEY_FILE, EE_SCOPE)

--- a/demos/server-auth/config.py
+++ b/demos/server-auth/config.py
@@ -11,5 +11,5 @@ from oauth2client.service_account import ServiceAccountCredentials
 EE_SCOPE = 'https://www.googleapis.com/auth/earthengine'
 EE_PRIVATE_KEY_FILE = 'privatekey.json'
 
-EE_CREDENTIALS = ServiceAccountCredentials(
+EE_CREDENTIALS = ServiceAccountCredentials.from_json_keyfile_name(
   EE_PRIVATE_KEY_FILE, EE_SCOPE)


### PR DESCRIPTION
Changes in oauth2client seem have broken this example.

The oauth2client.client.SignedJwtAssertionCredentials class used at 
https://github.com/google/earthengine-api/blob/8c1ad6a94b9151d61c8e176191ed53ee1dcae379/python/ee/_helpers.py#L60
moved to oauth2client.service_account.ServiceAccountCredentials in version 2.0.0
See: https://github.com/google/oauth2client/issues/401

The method I'm proposing here uses a private key in json format instead, which seems to be the recommended format and does not require conversion from .p12 to .pem.
See: https://github.com/google/oauth2client/blob/master/CHANGELOG.md#v200

The ServiceAccountCredentionals function in _helpers.py could be modified to return 
```python
oauth2client.service_account.ServiceAccountCredentials.from_p12_keyfile(
     email, key_file, scopes=oauth.SCOPE)
```
... but I've found this to be finicky when running on dev_appserver due to competing crypto libraries. 