### PR TITLE
extend du to support tables

### DIFF
--- a/python/ee/cli/commands.py
+++ b/python/ee/cli/commands.py
@@ -667,6 +667,7 @@ class SizeCommand(object):
   def _get_size(self, asset):
     """Returns the size of the given asset in bytes."""
     size_parsers = {
+        'Table': self._get_size_table,
         'Image': self._get_size_image,
         'Folder': self._get_size_folder,
         'ImageCollection': self._get_size_image_collection
@@ -677,6 +678,11 @@ class SizeCommand(object):
           'Cannot get size for asset type "%s"' % asset['type'])
 
     return size_parsers[asset['type']](asset)
+
+  def _get_size_table(self, asset):
+    info = ee.data.getInfo(asset['id'])
+
+    return info['properties']['system:asset_size']
 
   def _get_size_image(self, asset):
     info = ee.data.getInfo(asset['id'])


### PR DESCRIPTION
A small bugfix to support to support `Table` user asset type, otherwise, an error is thrown:

> Cannot get size for asset type "Table"

