### PR TITLE
Service Account can now take a dictionary input

### DIFF
--- a/python/ee/_helpers.py
+++ b/python/ee/_helpers.py
@@ -62,7 +62,10 @@ def ServiceAccountCredentials(email, key_file=None, key_data=None):
   try:
     # oauth2client v2+ and JSON key
     sa_creds = oauth2client.service_account.ServiceAccountCredentials
-    credentials = sa_creds.from_json_keyfile_name(key_file, oauth.SCOPE)
+    if key_file:
+      credentials = sa_creds.from_json_keyfile_name(key_file, oauth.SCOPE)
+    else:
+      credentials = sa_creds.from_json_keyfile_dict(key_data, oauth.SCOPE)
   except ValueError:
     # oauth2client v2+ and PEM key
     raise NotImplementedError(


### PR DESCRIPTION
### Issue

Noted [issue discussed on the Developers Group](https://groups.google.com/forum/#!topic/google-earth-engine-developers/nWbibB_fEtM), where the `ServiceAccountCredentials(email, key_file=None, key_data=None):` function should take the `key_data`, however it was not implemented. 

Made a quick logic addition to address this, and tested locally : all seems well as shown in the screenshot.

![working_example](https://user-images.githubusercontent.com/6503031/37211688-0b51a49e-23ad-11e8-8a0a-f66bc6799c23.png)


### CLA
THis is my first PR to the project - I confirm I have signed my CLA.