### PR TITLE
Add --status argument to query only tasks with a specified status

### DIFF
--- a/python/ee/cli/commands.py
+++ b/python/ee/cli/commands.py
@@ -870,16 +870,23 @@ class TaskListCommand(object):
 
   name = 'list'
 
-  def __init__(self, unused_parser):
-    pass
+  def __init__(self, parser):
+    parser.add_argument('--status', '-s', required=False, nargs='*',
+                        choices=['READY', 'RUNNING', 'COMPLETED', 'FAILED',
+                              'CANCELLED', 'UNKNOWN'],
+                        help=('List tasks only with a given status'))
 
-  def run(self, unused_args, config):
+  def run(self, args, config):
     config.ee_init()
+    status = args.status
     tasks = ee.data.getTaskList()
     descs = [utils.truncate(task.get('description', ''), 40) for task in tasks]
     desc_length = max(len(word) for word in descs)
     format_str = '{:25s} {:13s} {:%ds} {:10s} {:s}' % (desc_length + 1)
     for task in tasks:
+      if status and task['state'] not in status:
+        continue
+
       truncated_desc = utils.truncate(task.get('description', ''), 40)
       task_type = TASK_TYPES.get(task['task_type'], 'Unknown')
       print(format_str.format(


### PR DESCRIPTION
Allows querying tasks only with a given status. 

Might be better if EE backend (/tasklist) can support status as an argument.

```
>earthengine task list --status RUNNING
OUYT544FSQ2E3ITKTKZOS74X  Upload        Asset ingestion: users/gena/HAND/by-catc..  RUNNING    ---
IIHLUH6XUCDG4FWXT3KCRWPH  Export.image  EMODnet_shoreline_MEAN                      RUNNING    ---
ZPRPOQGKZJ25OJUFHZSXI6VL  Export.image  EMODnet_shoreline_HAT                       RUNNING    ---
QPINWP2NWSKK7Q6S2W6LS5CR  Export.image  EMODnet_shoreline_LAT                       RUNNING    ---

>earthengine task list --status RUNNING FAILED
OUYT544FSQ2E3ITKTKZOS74X  Upload        Asset ingestion: users/gena/HAND/by-catc..  RUNNING    ---
ASHXOTGEMUDH32FFAS6DWVFH  Upload        Asset ingestion: users/gena/HAND/by-catc..  FAILED     Unable to open SRTM_30_max4_1040020050_2500_hand.tif.
IIHLUH6XUCDG4FWXT3KCRWPH  Export.image  EMODnet_shoreline_MEAN                      RUNNING    ---
ZPRPOQGKZJ25OJUFHZSXI6VL  Export.image  EMODnet_shoreline_HAT                       RUNNING    ---
QPINWP2NWSKK7Q6S2W6LS5CR  Export.image  EMODnet_shoreline_LAT                       RUNNING    ---
5OQ53SILTIWCREGXSHNQZJBA  Export.image  EMODnet_shoreline_MEAN                      FAILED     Kernel is too large: 445 pixels (max size, in pixels, is 256).
F2WKP7MPNF2ER374NOAUJVRZ  Export.image  EMODnet_shoreline_HAT                       FAILED     Kernel is too large: 445 pixels (max size, in pixels, is 256).
XUROTQTUTCROZ3CGKZSTPO4Z  Export.image  EMODnet_shoreline_LAT                       FAILED     Kernel is too large: 445 pixels (max size, in pixels, is 256).
```

The argument should be probably just a single status, not a list, not sure about that.

