### PR TITLE
GCS list bug fix + Python3 Compatibility fix

### DIFF
--- a/python/ee/cli/utils.py
+++ b/python/ee/cli/utils.py
@@ -21,6 +21,13 @@ import oauth2client.client
 
 import ee
 
+try:                     # Python 3.x
+  import urllib.parse
+  urlencode = urllib.parse.urlencode
+except ImportError:      # Python 2.x
+  import urllib
+  urlencode = urllib.urlencode
+
 HOMEDIR = os.path.expanduser('~')
 EE_CONFIG_FILE = 'EE_CONFIG_FILE'
 DEFAULT_EE_CONFIG_FILE_RELATIVE = os.path.join(
@@ -247,7 +254,7 @@ def _gcs_ls(bucket, prefix=''):
       params['pageToken'] = next_page_token
     if prefix:
       params['prefix'] = prefix
-    payload = urllib.urlencode(params)
+    payload = urlencode(params)
 
     url = base_url + '?' + payload
     try:

--- a/python/ee/cli/utils.py
+++ b/python/ee/cli/utils.py
@@ -210,7 +210,7 @@ def expand_gcs_wildcards(source_files):
     # of items returned by that API call
 
     # Capture the part of the path after gs:// and before the first /
-    bucket_regex = 'gs://([a-z0-9_.-]+)(/.*)'
+    bucket_regex = 'gs://([a-z0-9_.-]+)/(.*)'
     bucket_match = re.match(bucket_regex, source)
     if bucket_match:
       bucket, rest = bucket_match.group(1, 2)


### PR DESCRIPTION
`urllib.urlencode()` is no longer available in Python3, but the code uses it in this raw form. I fix this.

The GCS API permits wildcards, but the code doesn't send them to the server correctly resulting in no valid items being listed. I fix this.