### PR TITLE
Forcing the use of delayed execution for different TF versions

### DIFF
--- a/python/ee/cli/commands.py
+++ b/python/ee/cli/commands.py
@@ -37,6 +37,10 @@ try:
   from tensorflow.compat.v1.saved_model import signature_def_utils
   # Prevent TensorFlow from logging anything at the python level.
   tf.logging.set_verbosity(tf.logging.ERROR)
+
+  # if running TF2.0 disable eager execution for model prep
+  tf.disable_eager_execution()
+
   TENSORFLOW_INSTALLED = True
 except ImportError:
   TENSORFLOW_INSTALLED = False


### PR DESCRIPTION
When using TensorFlow 2, eager execution is the default execution mode so running the CLI command `earthengine model prepare` results in an error [here](https://github.com/google/earthengine-api/blob/master/python/ee/cli/commands.py#L1765) in the model preparation process "RuntimeError: tf.placeholder() is not compatible with eager execution." as eager execution does not allow for the use of tf.placeholder()

Added a line to force the use of delayed execution for TensorFlow to prevent this error with different version.