### PR TITLE
Update _cloud_api_utils.py

### DIFF
--- a/python/ee/_cloud_api_utils.py
+++ b/python/ee/_cloud_api_utils.py
@@ -18,9 +18,9 @@ import re
 import warnings
 
 from . import ee_exception
-from apiclient import discovery
-from apiclient import http
-from apiclient import model
+from googleapiclient import discovery
+from googleapiclient import http
+from googleapiclient import model
 from google_auth_httplib2 import AuthorizedHttp
 
 # We use the urllib3-aware shim if it's available.


### PR DESCRIPTION
Recent changes in the google api client result in an error:
```
AttributeError: module 'googleapiclient' has no attribute '__version__'
```
When trying to import from `apiclient`, it is suggested to import from `googleapiclient` instead (see https://github.com/googleapis/google-api-python-client/issues/870 ).