### PR TITLE
It's recommended to import from googleapiclient

### DIFF
--- a/python/ee/_cloud_api_utils.py
+++ b/python/ee/_cloud_api_utils.py
@@ -18,9 +18,9 @@ import re
 import warnings
 
 from . import ee_exception
-from apiclient import discovery
-from apiclient import http
-from apiclient import model
+from googleapiclient import discovery
+from googleapiclient import http
+from googleapiclient import model
 from google_auth_httplib2 import AuthorizedHttp
 
 # We use the urllib3-aware shim if it's available.

--- a/python/ee/data.py
+++ b/python/ee/data.py
@@ -27,7 +27,7 @@ from . import deprecation
 from . import encodable
 from . import oauth
 from . import serializer
-import apiclient
+import googleapiclient
 
 from . import ee_exception
 
@@ -336,7 +336,7 @@ def _execute_cloud_call(call, num_retries=MAX_RETRIES):
   """
   try:
     return call.execute(num_retries=num_retries)
-  except apiclient.errors.HttpError as e:
+  except googleapiclient.errors.HttpError as e:
     raise _translate_cloud_exception(e)
 
 
@@ -344,7 +344,7 @@ def _translate_cloud_exception(http_error):
   """Translates a Cloud API exception into an EEException.
 
   Args:
-    http_error: An apiclient.errors.HttpError.
+    http_error: An googleapiclient.errors.HttpError.
 
   Returns:
     An EEException bearing the error message from http_error.
@@ -419,7 +419,7 @@ def getInfo(asset_id):
       return _cloud_api_resource.projects().assets().get(
           name=_cloud_api_utils.convert_asset_id_to_asset_name(asset_id),
           prettyPrint=False).execute(num_retries=MAX_RETRIES)
-    except apiclient.errors.HttpError as e:
+    except googleapiclient.errors.HttpError as e:
       if e.resp.status == 404:
         return None
       else:
@@ -1218,7 +1218,7 @@ def listOperations(project=None):
       operations += response.get('operations', [])
       request = _cloud_api_resource.projects().operations().list_next(
           request, response)
-    except apiclient.errors.HttpError as e:
+    except googleapiclient.errors.HttpError as e:
       raise _translate_cloud_exception(e)
   return operations
 
@@ -1251,7 +1251,7 @@ def getTaskStatus(taskId):
             name=_cloud_api_utils.convert_task_id_to_operation_name(
                 one_id)).execute(num_retries=MAX_RETRIES)
         result.append(_cloud_api_utils.convert_operation_to_task(operation))
-      except apiclient.errors.HttpError as e:
+      except googleapiclient.errors.HttpError as e:
         if e.resp.status == 404:
           result.append({'id': one_id, 'state': 'UNKNOWN'})
         else:


### PR DESCRIPTION
Fix this error in `google-api-python-client==1.8.1`: https://github.com/googleapis/google-api-python-client/issues/870

```
ubuntu@94e3c92a8c62:/app$ python -c 'import apiclient'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/venvs/venv2/local/lib/python2.7/site-packages/apiclient/__init__.py", line 22, in <module>
    __version__ = googleapiclient.__version__
AttributeError: 'module' object has no attribute '__version__'
```