### PR TITLE
It's recommended to import from googleapiclient

### DIFF
--- a/python/ee/_cloud_api_utils.py
+++ b/python/ee/_cloud_api_utils.py
@@ -18,9 +18,9 @@ import re
 import warnings
 
 from . import ee_exception
-from apiclient import discovery
-from apiclient import http
-from apiclient import model
+from googleapiclient import discovery
+from googleapiclient import http
+from googleapiclient import model
 from google_auth_httplib2 import AuthorizedHttp
 
 # We use the urllib3-aware shim if it's available.


### PR DESCRIPTION
Fix this error in `google-api-python-client`: https://github.com/googleapis/google-api-python-client/issues/870

```
ubuntu@94e3c92a8c62:/app$ python -c 'import apiclient'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/venvs/venv2/local/lib/python2.7/site-packages/apiclient/__init__.py", line 22, in <module>
    __version__ = googleapiclient.__version__
AttributeError: 'module' object has no attribute '__version__'
```