### PR TITLE
py37: use Dict not dict for type check

### DIFF
--- a/python/ee/data.py
+++ b/python/ee/data.py
@@ -539,7 +539,7 @@ def listImages(params: Dict[str, Any]) -> Dict[str, Optional[List[int]]]:
   return images
 
 
-def listAssets(params: dict[str, Any]) -> dict[str, List[Any]]:
+def listAssets(params: Dict[str, Any]) -> Dict[str, List[Any]]:
   """Returns the assets in a folder.
 
   Args:


### PR DESCRIPTION
Also, `cli/commands.py` needs to be changed

https://issuetracker.google.com/issues/297249195