### PR TITLE
fix: allow use of List as parameters of And and Or filter constructor

### DIFF
--- a/javascript/src/filter.js
+++ b/javascript/src/filter.js
@@ -15,6 +15,7 @@ goog.require('ee.Geometry');
 goog.require('ee.arguments');
 goog.require('goog.array');
 goog.require('goog.string');
+goog.require('ee.List');
 
 
 goog.requireType('ee.FeatureCollection');
@@ -253,7 +254,7 @@ ee.Filter.lte = function(name, value) {
  * @export
  */
 ee.Filter.and = function(var_args) {
-  var args = Array.prototype.slice.call(arguments);
+  var args = arguments instanceof ee.List ? arguments : Array.prototype.slice.call(arguments);
   return /** @type {ee.Filter} */(ee.ApiFunction._call('Filter.and', args));
 };
 
@@ -266,7 +267,7 @@ ee.Filter.and = function(var_args) {
  * @export
  */
 ee.Filter.or = function(var_args) {
-  var args = Array.prototype.slice.call(arguments);
+  var args = arguments instanceof ee.List ? arguments : Array.prototype.slice.call(arguments);
   return /** @type {ee.Filter} */(ee.ApiFunction._call('Filter.or', args));
 };
 

--- a/python/ee/filter.py
+++ b/python/ee/filter.py
@@ -14,6 +14,7 @@ from ee import _utils
 from ee import apifunction
 from ee import computedobject
 from ee import ee_exception
+from ee import ee_list
 
 
 # A map from the deprecated old-style comparison operator names to API
@@ -198,14 +199,14 @@ class Filter(computedobject.ComputedObject):
   @staticmethod
   def And(*args):
     """Combine two or more filters using boolean AND."""
-    if len(args) == 1 and isinstance(args[0], (list, tuple)):
+    if len(args) == 1 and isinstance(args[0], (list, tuple, ee_list.List)):
       args = args[0]
     return apifunction.ApiFunction.call_('Filter.and', args)
 
   @staticmethod
   def Or(*args):
     """Combine two or more filters using boolean OR."""
-    if len(args) == 1 and isinstance(args[0], (list, tuple)):
+    if len(args) == 1 and isinstance(args[0], (list, tuple, ee_List.List)):
       args = args[0]
     return apifunction.ApiFunction.call_('Filter.or', args)
 


### PR DESCRIPTION
ref: https://issuetracker.google.com/issues/322838709

I know it will not be merged but I think this solution is not completely dum. I'm not js expert I don't know if I'm allowed to require List directly from the Filter.js file. 

Happy to discuss it in the issue tracker and see this being added to the next realease of the API. 