### PR TITLE
Mobile Friendly UI: Debounce the resize event

### DIFF
--- a/javascript/src/examples/UserInterface/MobileFriendlyUI.js
+++ b/javascript/src/examples/UserInterface/MobileFriendlyUI.js
@@ -189,4 +189,4 @@ function configLayout(deviceInfo) {
   }
 }
 
-ui.root.onResize(configLayout);
+ui.root.onResize(ui.util.debounce(configLayout, 100));


### PR DESCRIPTION
This reduces flickering of the map layer when resizing the window.