### PR TITLE
Refactor usages of deprecated goog.structs.Map methods

### DIFF
--- a/javascript/src/floattileoverlay.js
+++ b/javascript/src/floattileoverlay.js
@@ -130,7 +130,7 @@ ee.FloatTileOverlay =
 
   /** @return {number} The number of tiles successfully loaded. */
   getLoadedFloatTilesCount() {
-    return this.floatTiles_.getCount();
+    return this.floatTiles_.size;
   }
 
   /**

--- a/javascript/src/layers/abstractoverlay.js
+++ b/javascript/src/layers/abstractoverlay.js
@@ -135,7 +135,7 @@ ee.layers.AbstractOverlay = class extends goog.events.EventTarget {
     this.opacity = opacity;
     this.tilesById.forEach(function(tile) {
       goog.style.setOpacity(tile.div, this.opacity);
-    }, this);
+    }.bind(this));
   }
 
   /**
@@ -201,7 +201,7 @@ ee.layers.AbstractOverlay = class extends goog.events.EventTarget {
    */
   releaseTile(tileDiv) {
     var tile = this.tilesById.get(tileDiv.id);
-    this.tilesById.remove(tileDiv.id);
+    this.tilesById.delete(tileDiv.id);
     if (tile) {
       tile.abort();
       goog.dispose(tile);
@@ -283,7 +283,7 @@ ee.layers.AbstractOverlay = class extends goog.events.EventTarget {
    * @private
    */
   getTileCountForStatus_(status) {
-    return goog.array.count(this.tilesById.getValues(), function(tile) {
+    return goog.array.count([...this.tilesById.values()], function(tile) {
       return tile.getStatus() == status;
     });
   }

--- a/javascript/src/maptilemanager.js
+++ b/javascript/src/maptilemanager.js
@@ -74,7 +74,7 @@ ee.MapTileManager = class extends goog.events.EventTarget {
    * @return {number} The number of requests in flight or pending send.
    */
   getOutstandingCount() {
-    return this.requests_.getCount();
+    return this.requests_.size;
   }
 
   /**
@@ -160,7 +160,7 @@ ee.MapTileManager = class extends goog.events.EventTarget {
    * @private
    */
   releaseRequest_(request) {
-    this.requests_.remove(request.getId());
+    this.requests_.delete(request.getId());
     if (request.getImageLoader()) {
       this.releaseObject_(request.getToken());
       request.getImageLoader().dispose();
@@ -189,7 +189,7 @@ ee.MapTileManager = class extends goog.events.EventTarget {
 
     // Call dispose on each request.
     var requests = this.requests_;
-    goog.array.forEach(requests.getValues(), function(value) {
+    goog.array.forEach([...requests.values()], function(value) {
       value.dispose();
     });
     requests.clear();


### PR DESCRIPTION
Instead, we use standard  alternatives that are compatible with the builtin Map type, e.g. `size` instead of `getCount()`, `delete` instead of `remove`, etc.

This makes progress toward entirely replacing the usage with a native `Map`.